### PR TITLE
Add header retain height on refresh

### DIFF
--- a/ptr-lib/src/in/srain/cube/views/ptr/PtrFrameLayout.java
+++ b/ptr-lib/src/in/srain/cube/views/ptr/PtrFrameLayout.java
@@ -46,6 +46,7 @@ public class PtrFrameLayout extends ViewGroup {
     private View mHeaderView;
     private PtrUIHandlerHolder mPtrUIHandlerHolder = PtrUIHandlerHolder.create();
     private PtrHandler mPtrHandler;
+    private int mHeaderRetainHeightOnRefresh = -1;
     // working parameters
     private ScrollChecker mScrollChecker;
     private PointF mPtLastMove = new PointF();
@@ -436,7 +437,8 @@ public class PtrFrameLayout extends ViewGroup {
             if (mKeepHeaderWhenRefresh) {
                 // scroll header back
                 if (mCurrentPos > mHeaderHeight && !stayForLoading) {
-                    mScrollChecker.tryToScrollTo(mHeaderHeight, mDurationToClose);
+                	int scrollHeight = mHeaderRetainHeightOnRefresh >= 0 ? mHeaderRetainHeightOnRefresh : mHeaderHeight;
+                    mScrollChecker.tryToScrollTo(scrollHeight, mDurationToClose);
                 } else {
                     // do nothing
                 }
@@ -746,6 +748,14 @@ public class PtrFrameLayout extends ViewGroup {
 
     public float getRatioOfHeaderToHeightRefresh() {
         return mRatioOfHeaderHeightToRefresh;
+    }
+
+    public void setHeaderRetainHeightOnRefresh(int headerRetainHeightOnRefresh) {
+    	mHeaderRetainHeightOnRefresh = headerRetainHeightOnRefresh;
+    }
+
+    public int getHeaderRetainHeightOnRefresh() {
+    	return mHeaderRetainHeightOnRefresh;
     }
 
     public boolean isKeepHeaderWhenRefresh() {


### PR DESCRIPTION
新增加一个配置，如果设置了就override默认的(释放后如果还在刷新停在和header一样高的地方)，而是停在设置的高度。

这样更加灵活了。当然也可以考虑把这个参数变成个常量，来表示是header的多少倍。但是我觉得现在这g 个PR这样就已经能满足不少人的需求了。