### PR TITLE
Fix A problem with  disableWhenHorizontalMove()

### DIFF
--- a/ptr-lib/src/in/srain/cube/views/ptr/PtrFrameLayout.java
+++ b/ptr-lib/src/in/srain/cube/views/ptr/PtrFrameLayout.java
@@ -300,7 +300,7 @@ public class PtrFrameLayout extends ViewGroup {
                 float offsetX = mPtrIndicator.getOffsetX();
                 float offsetY = mPtrIndicator.getOffsetY();
 
-                if (mDisableWhenHorizontalMove && !mPreventForHorizontal && (Math.abs(offsetX) > mPagingTouchSlop || Math.abs(offsetX) > 3 * Math.abs(offsetY))) {
+                if (mDisableWhenHorizontalMove && !mPreventForHorizontal && (Math.abs(offsetX) > mPagingTouchSlop && Math.abs(offsetX) > Math.abs(offsetY))) {
                     if (mPtrIndicator.isInStartPosition()) {
                         mPreventForHorizontal = true;
                     }


### PR DESCRIPTION
如果在默认位置时,手指按下后,小幅度上滑接着下滑,就会出现无法下拉的情况,303行:Math.abs(offsetX) > 3 * Math.abs(offsetY);这里的判断会在非常小的滑动时产生错误的判断,导致mPreventForHorizontal=true
此提交仅供参考.Thanks!