### PR TITLE
修复ViewPager等左右滑动View时，PtrFrameLayout.disableWhenHorizontalMove(true);还是容易触发下拉的问题

### DIFF
--- a/ptr-lib/src/in/srain/cube/views/ptr/PtrFrameLayout.java
+++ b/ptr-lib/src/in/srain/cube/views/ptr/PtrFrameLayout.java
@@ -46,7 +46,6 @@ public class PtrFrameLayout extends ViewGroup {
     private PtrHandler mPtrHandler;
     // working parameters
     private ScrollChecker mScrollChecker;
-    private int mPagingTouchSlop;
     private int mHeaderHeight;
     private boolean mDisableWhenHorizontalMove = false;
     private int mFlag = 0x00;
@@ -105,9 +104,6 @@ public class PtrFrameLayout extends ViewGroup {
         }
 
         mScrollChecker = new ScrollChecker();
-
-        final ViewConfiguration conf = ViewConfiguration.get(getContext());
-        mPagingTouchSlop = conf.getScaledTouchSlop() * 2;
     }
 
     @Override
@@ -314,7 +310,7 @@ public class PtrFrameLayout extends ViewGroup {
                 float offsetX = mPtrIndicator.getOffsetX();
                 float offsetY = mPtrIndicator.getOffsetY();
 
-                if (mDisableWhenHorizontalMove && !mPreventForHorizontal && (Math.abs(offsetX) > mPagingTouchSlop && Math.abs(offsetX) > Math.abs(offsetY))) {
+                if (mDisableWhenHorizontalMove && !mPreventForHorizontal && Math.abs(offsetX) > Math.abs(offsetY)) {
                     if (mPtrIndicator.isInStartPosition()) {
                         mPreventForHorizontal = true;
                     }


### PR DESCRIPTION
修复嵌套ViewPager等左右滑动的View时调用PtrFrameLayout.disableWhenHorizontalMove(true)还是容易触发下拉刷新的问题，问题的分析和方案在https://github.com/liaohuqiu/android-Ultra-Pull-To-Refresh/issues/133
