### PR TITLE
fix long to int overflow bug.

### DIFF
--- a/ptr-lib/src/in/srain/cube/views/ptr/PtrFrameLayout.java
+++ b/ptr-lib/src/in/srain/cube/views/ptr/PtrFrameLayout.java
@@ -604,7 +604,7 @@ public class PtrFrameLayout extends ViewGroup {
             mRefreshCompleteHook.reset();
         }
 
-        int delay = (int) (mLoadingMinTime - (System.currentTimeMillis() - mLoadingStartTime));
+        long delay = mLoadingMinTime - (System.currentTimeMillis() - mLoadingStartTime);
         if (delay <= 0) {
             if (DEBUG) {
                 PtrCLog.d(LOG_TAG, "performRefreshComplete at once");


### PR DESCRIPTION
In some cases, if the mLoadingStartTime has not yet been assigned, the refreshComplete () method is called, causing the long to int overflow, depending on the timestamp at which time enter the error logic.